### PR TITLE
Adding method to destroy client in pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var SUPPORTED_REDIS_OPTIONS = [
   'parser', 'return_buffers', 'detect_buffers', 'socket_nodelay',
   'socket_keepalive', 'no_ready_check', 'enable_offline_queue',
   'retry_max_delay', 'connect_timeout', 'max_attempts', 'family',
-  'auth_pass', 'db'
+  'auth_pass', 'db', 'retry_strategy'
 ];
 
 var SUPPORTED_POOL_OPTIONS = [
@@ -82,7 +82,7 @@ RedisPool.prototype._initialize = function() {
   // The destroy function is called when client connection needs to be closed.
   poolSettings.destroy = function(client) {
     try {
-      // Flush when closing. 
+      // Flush when closing.
       client.end(true);
 
     } catch (err) {
@@ -109,6 +109,11 @@ RedisPool.prototype.acquireDb = function(cb, db, priority) {
     }
     return cb(err, client);
   }, priority);
+};
+
+// Destroy a database connection in the pool.
+RedisPool.prototype.destroy = function(client) {
+  this._pool.destroy(client);
 };
 
 // Release a database connection to the pool.


### PR DESCRIPTION
And also adding retry_strategy option as supported option.

This is related to https://github.com/joshuah/sol-redis-pool/issues/18.

As stated in the issue, if I use any of the redis settings to stop retrying the connection (e.g., max_attempts, retry_strategy, etc) the connection becomes closed but it still served up by the pool. In order to prevent this I believe I need a way to destroy the connection in the pool. This way, if the redis server comes back up I can attempt to reconnect.

(If this is not the right approach to this, please do let me know.)
