### PR TITLE
Add promise support to redis pool connections using bluebird.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ var redis = require('redis');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var Pool = require('generic-pool').Pool;
+var bluebird = require('bluebird');
+
+bluebird.promisifyAll(redis.RedisClient.prototype);
+bluebird.promisifyAll(redis.Multi.prototype);
 
 var SUPPORTED_REDIS_OPTIONS = [
   'host', 'port', 'path', 'url', 'password',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git://github.com/joshuah/sol-redis-pool.git"
   },
   "dependencies": {
+    "bluebird": "^3.4.6",
     "generic-pool": "2.2.1",
     "redis": ">= 2.6.2"
   },


### PR DESCRIPTION
This PR adds support for promises to the redis pool connections using the method recommended in [the node redis client npm docs](https://www.npmjs.com/package/redis#promises). It adds the `bluebird` package to `package.json` and the following lines to the top of the `index.js` file:

```js
var bluebird = require('bluebird');

bluebird.promisifyAll(redis.RedisClient.prototype);
bluebird.promisifyAll(redis.Multi.prototype);
```

All pool connections can now be used with promises as described in the npm redis client examples. (See link above)

This also resolves my previous issue, #21.