### PR TITLE
Add prefix option to SUPPORTED_REDIS_OPTIONS.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var SUPPORTED_REDIS_OPTIONS = [
   'string_numbers', 'return_buffers', 'detect_buffers', 
   'socket_keepalive', 'no_ready_check', 'enable_offline_queue',
   'retry_unfulfilled_commands', 'family', 'disable_resubscribing',
-  'rename_commands', 'auth_pass', 'db', 'retry_strategy', 'tls'
+  'rename_commands', 'auth_pass', 'db', 'retry_strategy', 'tls', 'prefix'
 ];
 
 var SUPPORTED_POOL_OPTIONS = [


### PR DESCRIPTION
I need the `prefix` option. We can simply add it to the supported redis options for it to work.